### PR TITLE
Make the text parser an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ edition = "2018"
 failure = "0.1.5"
 leb128 = "0.2.4"
 walrus = "0.8.0"
-wasm-webidl-bindings-text-parser = { path = "crates/text-parser" }
+wasm-webidl-bindings-text-parser = { path = "crates/text-parser", optional = true }
 id-arena = "2.2.1"
 
 [workspace]
 members = [
     "crates/text-parser"
 ]
+
+[features]
+text = ['wasm-webidl-bindings-text-parser']

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "text")]
 use crate::text;
 use id_arena::{Arena, Id};
 use std::borrow::Cow;
@@ -269,6 +270,7 @@ impl<'a> BuildAstActions<'a> {
     }
 }
 
+#[cfg(feature = "text")]
 impl<'a> text::Actions for BuildAstActions<'a> {
     type WebidlBindingsSection = ();
     fn webidl_bindings_section(&mut self, _types: (), _bindings: ()) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,4 +93,5 @@ let new_raw_wasm = module.emit_wasm();
 
 pub mod ast;
 pub mod binary;
+#[cfg(feature = "text")]
 pub mod text;


### PR DESCRIPTION
The build times are so high this should help alleviate it a bit with
wasm-bindgen at least which doesn't need the text support.