### PR TITLE
doc(readme) Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### What's Inside
 
-* A parser for the straw proposal text format. See `src/text/grammar.lalrpop`.
+* A parser for the straw proposal text format. See `crates/text-parser/src/grammar.lalrpop`.
 
 * A set of AST types for representing and manipulating WebIDL bindings. See
   `src/ast.rs`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ let mut config = walrus::ModuleConfig::default();
 // mapping from indices in the original Wasm binary to their newly assigned
 // walrus IDs.
 //
-// This is where we will parse the Web IDL bidnings text.
+// This is where we will parse the Web IDL bindings text.
 config.on_parse(|module, indices_to_ids| {
     let webidl_bindings = text::parse(module, indices_to_ids, r#"
         type $TextEncoderEncodeIntoResult

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ config.on_parse(|module, indices_to_ids| {
     let webidl_bindings = text::parse(module, indices_to_ids, r#"
         type $TextEncoderEncodeIntoResult
             (dict
-                (field "read" unsigned_long_long)
-                (field "written" unsigned_long_long))
+                (field "read" unsigned long long)
+                (field "written" unsigned long long))
 
         type $EncodeIntoFuncWebIDL
             (func (method any)
@@ -61,7 +61,7 @@ config.on_parse(|module, indices_to_ids| {
             (param
                 (as any 0)
                 (as any 1)
-                (view uint8 2 3))
+                (view Int8Array 2 3))
             (result
                 (as i64 (field 0 (get 0)))
                 (as i64 (field 1 (get 0))))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@ config.on_parse(|module, indices_to_ids| {
     let webidl_bindings = text::parse(module, indices_to_ids, r#"
         type $TextEncoderEncodeIntoResult
             (dict
-                (field "read" unsigned_long_long)
-                (field "written" unsigned_long_long))
+                (field "read" unsigned long long)
+                (field "written" unsigned long long))
 
         type $EncodeIntoFuncWebIDL
             (func (method any)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ let mut config = walrus::ModuleConfig::default();
 // mapping from indices in the original Wasm binary to their newly assigned
 // walrus IDs.
 //
-// This is where we will parse the Web IDL bidnings text.
+// This is where we will parse the Web IDL bindings text.
 config.on_parse(|module, indices_to_ids| {
     let webidl_bindings = text::parse(module, indices_to_ids, r#"
         type $TextEncoderEncodeIntoResult

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 ## What's Inside
 
-* A parser for the straw proposal text format. See `src/text/grammar.lalrpop`.
+* A parser for the straw proposal text format. See `crates/text-parser/src/grammar.lalrpop`.
 
 * A set of AST types for representing and manipulating WebIDL bindings. See
   `src/ast.rs`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ config.on_parse(|module, indices_to_ids| {
             (param
                 (as any 0)
                 (as any 1)
-                (view uint8 2 3))
+                (view Int8Array 2 3))
             (result
                 (as i64 (field 0 (get 0)))
                 (as i64 (field 1 (get 0))))


### PR DESCRIPTION
Small PR to fix the path to `grammar.lalrpop`, some types in the example etc., in the `README.md` file.