### PR TITLE
feat: Make params or results optional in `func-binding`

### DIFF
--- a/crates/text-parser/src/actions.rs
+++ b/crates/text-parser/src/actions.rs
@@ -95,8 +95,8 @@ pub trait Actions {
         name: Option<&str>,
         wasm_ty: Self::WasmFuncTypeRef,
         webidl_ty: Self::WebidlTypeRef,
-        params: Self::OutgoingBindingMap,
-        result: Self::IncomingBindingMap,
+        params: Option<Self::OutgoingBindingMap>,
+        result: Option<Self::IncomingBindingMap>,
     ) -> Self::ImportBinding;
 
     type ExportBinding;
@@ -105,8 +105,8 @@ pub trait Actions {
         name: Option<&str>,
         wasm_ty: Self::WasmFuncTypeRef,
         webidl_ty: Self::WebidlTypeRef,
-        params: Self::IncomingBindingMap,
-        result: Self::OutgoingBindingMap,
+        params: Option<Self::IncomingBindingMap>,
+        result: Option<Self::OutgoingBindingMap>,
     ) -> Self::ExportBinding;
 
     type Bind;

--- a/crates/text-parser/src/grammar.lalrpop
+++ b/crates/text-parser/src/grammar.lalrpop
@@ -99,9 +99,15 @@ pub(crate) ImportBinding: A::ImportBinding =
     "import"
     <wasm_ty:WasmFuncTypeRef>
     <webidl_ty:WebidlTypeRef>
-    "(" "param" <params:OutgoingBindingMap> ")"
-    "(" "result" <result:IncomingBindingMap> ")" =>
-        actions.import_binding(name, wasm_ty, webidl_ty, params, result);
+    <webidl_params:("(" "param" OutgoingBindingMap ")")?>
+    <webidl_result:("(" "result" IncomingBindingMap ")")?> =>
+        actions.import_binding(
+            name,
+            wasm_ty,
+            webidl_ty,
+            webidl_params.map(|params| params.2),
+            webidl_result.map(|result| result.2),
+        );
 
 pub(crate) ExportBinding: A::ExportBinding =
     "func-binding"
@@ -109,9 +115,15 @@ pub(crate) ExportBinding: A::ExportBinding =
     "export"
     <wasm_ty:WasmFuncTypeRef>
     <webidl_ty:WebidlTypeRef>
-    "(" "param" <params:IncomingBindingMap> ")"
-    "(" "result" <result:OutgoingBindingMap> ")" =>
-        actions.export_binding(name, wasm_ty, webidl_ty, params, result);
+    <webidl_params:("(" "param" IncomingBindingMap ")")?>
+    <webidl_result:("(" "result" OutgoingBindingMap ")")?> =>
+        actions.export_binding(
+            name,
+            wasm_ty,
+            webidl_ty,
+            webidl_params.map(|params| params.2),
+            webidl_result.map(|result| result.2),
+        );
 
 pub(crate) Bind: A::Bind =
     "bind" <func:WasmFuncRef> <binding:BindingRef> =>

--- a/crates/text-parser/src/parser.rs
+++ b/crates/text-parser/src/parser.rs
@@ -203,8 +203,8 @@ mod tests {
             name: Option<&str>,
             wasm_ty: Self::WasmFuncTypeRef,
             webidl_ty: Self::WebidlTypeRef,
-            params: Self::OutgoingBindingMap,
-            result: Self::IncomingBindingMap,
+            params: Option<Self::OutgoingBindingMap>,
+            result: Option<Self::IncomingBindingMap>,
         ) -> Self::ImportBinding {
             t!("ImportBinding" name wasm_ty webidl_ty params result)
         }
@@ -215,8 +215,8 @@ mod tests {
             name: Option<&str>,
             wasm_ty: Self::WasmFuncTypeRef,
             webidl_ty: Self::WebidlTypeRef,
-            params: Self::IncomingBindingMap,
-            result: Self::OutgoingBindingMap,
+            params: Option<Self::IncomingBindingMap>,
+            result: Option<Self::OutgoingBindingMap>,
         ) -> Self::ExportBinding {
             t!("ExportBinding" name wasm_ty webidl_ty params result)
         }
@@ -629,7 +629,7 @@ mod tests {
                     t!("Some" "$encodeIntoBinding")
                     t!("WasmFuncTypeRefNamed" "$EncodeIntoFuncWasm")
                     t!("WebidlTypeRefNamed" "$EncodeIntoFuncWebIDL")
-                    t!("OutgoingBindingMap"
+                    t!("Some" t!("OutgoingBindingMap"
                        t!(t!("OutgoingBindingExpressionAs"
                              t!("WebidlScalarType" "any")
                              0)
@@ -639,8 +639,8 @@ mod tests {
                           t!("OutgoingBindingExpressionView"
                              t!("WebidlScalarType" "Uint8Array")
                              2
-                             3)))
-                    t!("IncomingBindingMap"
+                             3))))
+                    t!("Some" t!("IncomingBindingMap"
                        t!(t!("IncomingBindingExpressionAs"
                              t!("WasmValType" "i64")
                              t!("IncomingBindingExpressionField"
@@ -650,7 +650,7 @@ mod tests {
                              t!("WasmValType" "i64")
                              t!("IncomingBindingExpressionField"
                                 1
-                                t!("IncomingBindingExpressionGet" 0)))))))
+                                t!("IncomingBindingExpressionGet" 0))))))))
                 t!(t!("Bind"
                       t!("WasmFuncRefNamed" "$encodeInto")
                       t!("BindingRefNamed" "$encodeIntoBinding")))))
@@ -855,22 +855,22 @@ mod tests {
            t!("Some" "Yoyo")
            t!("WasmFuncTypeRefNamed" "MyWasmFunc")
            t!("WebidlTypeRefNamed" "MyWebidlFunc")
-           t!("OutgoingBindingMap"
+           t!("Some" t!("OutgoingBindingMap"
               t!(
                   t!("OutgoingBindingExpressionAs"
                      t!("WebidlScalarType" "any")
                      0
                   )
               )
-           )
-           t!("IncomingBindingMap"
+           ))
+           t!("Some" t!("IncomingBindingMap"
               t!(
                   t!("IncomingBindingExpressionAs"
                      t!("WasmValType" "i32")
                      t!("IncomingBindingExpressionGet" 0)
                   )
               )
-           )
+           ))
         )
     );
     ok!(
@@ -881,19 +881,33 @@ mod tests {
            t!("None")
            t!("WasmFuncTypeRefNamed" "MyWasmFunc")
            t!("WebidlTypeRefNamed" "MyWebidlFunc")
-           t!("OutgoingBindingMap" t!())
-           t!("IncomingBindingMap" t!())
+           t!("Some" t!("OutgoingBindingMap" t!()))
+           t!("Some" t!("IncomingBindingMap" t!()))
         )
     );
-    err!(
-        import_binding_err_1,
+    ok!(
+        import_binding_ok_3,
         ImportBindingParser,
-        "func-binding import MyWasmFunc MyWebidlFunc (param)"
+        "func-binding import MyWasmFunc MyWebidlFunc (param)",
+        t!("ImportBinding"
+           t!("None")
+           t!("WasmFuncTypeRefNamed" "MyWasmFunc")
+           t!("WebidlTypeRefNamed" "MyWebidlFunc")
+           t!("Some" t!("OutgoingBindingMap" t!()))
+           t!("None")
+        )
     );
-    err!(
-        import_binding_err_2,
+    ok!(
+        import_binding_ok_4,
         ImportBindingParser,
-        "func-binding import MyWasmFunc MyWebidlFunc (result)"
+        "func-binding import MyWasmFunc MyWebidlFunc (result)",
+        t!("ImportBinding"
+           t!("None")
+           t!("WasmFuncTypeRefNamed" "MyWasmFunc")
+           t!("WebidlTypeRefNamed" "MyWebidlFunc")
+           t!("None")
+           t!("Some" t!("IncomingBindingMap" t!()))
+        )
     );
     err!(
         import_binding_err_3,
@@ -924,22 +938,22 @@ mod tests {
            t!("Some" "$Yoyo")
            t!("WasmFuncTypeRefNamed" "MyWasmFunc")
            t!("WebidlTypeRefNamed" "MyWebidlFunc")
-           t!("IncomingBindingMap"
+           t!("Some" t!("IncomingBindingMap"
               t!(
                   t!("IncomingBindingExpressionAs"
                      t!("WasmValType" "i32")
                      t!("IncomingBindingExpressionGet" 0)
                   )
               )
-           )
-           t!("OutgoingBindingMap"
+           ))
+           t!("Some" t!("OutgoingBindingMap"
               t!(
                   t!("OutgoingBindingExpressionAs"
                      t!("WebidlScalarType" "any")
                      0
                   )
               )
-           )
+           ))
         )
     );
     ok!(
@@ -950,19 +964,33 @@ mod tests {
            t!("None")
            t!("WasmFuncTypeRefNamed" "$MyWasmFunc")
            t!("WebidlTypeRefNamed" "$MyWebidlFunc")
-           t!("IncomingBindingMap" t!())
-           t!("OutgoingBindingMap" t!())
+           t!("Some" t!("IncomingBindingMap" t!()))
+           t!("Some" t!("OutgoingBindingMap" t!()))
         )
     );
-    err!(
-        export_binding_err_1,
+    ok!(
+        export_binding_ok_3,
         ExportBindingParser,
-        "func-binding export MyWasmFunc MyWebidlFunc (param)"
+        "func-binding export $MyWasmFunc $MyWebidlFunc (param)",
+        t!("ExportBinding"
+           t!("None")
+           t!("WasmFuncTypeRefNamed" "$MyWasmFunc")
+           t!("WebidlTypeRefNamed" "$MyWebidlFunc")
+           t!("Some" t!("IncomingBindingMap" t!()))
+           t!("None")
+        )
     );
-    err!(
-        export_binding_err_2,
+    ok!(
+        export_binding_ok_4,
         ExportBindingParser,
-        "func-binding export MyWasmFunc MyWebidlFunc (result)"
+        "func-binding export $MyWasmFunc $MyWebidlFunc (result)",
+        t!("ExportBinding"
+           t!("None")
+           t!("WasmFuncTypeRefNamed" "$MyWasmFunc")
+           t!("WebidlTypeRefNamed" "$MyWebidlFunc")
+           t!("None")
+           t!("Some" t!("OutgoingBindingMap" t!()))
+        )
     );
     err!(
         export_binding_err_3,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -370,14 +370,14 @@ impl<'a> text::Actions for BuildAstActions<'a> {
         name: Option<&str>,
         wasm_ty: walrus::TypeId,
         webidl_ty: WebidlTypeRef,
-        params: OutgoingBindingMap,
-        result: IncomingBindingMap,
+        params: Option<OutgoingBindingMap>,
+        result: Option<IncomingBindingMap>,
     ) {
         let id: ImportBindingId = self.section.bindings.insert(ImportBinding {
             wasm_ty,
             webidl_ty,
-            params,
-            result,
+            params: params.unwrap_or_else(|| OutgoingBindingMap { bindings: vec![] }),
+            result: result.unwrap_or_else(|| IncomingBindingMap { bindings: vec![] }),
         });
         if let Some(name) = name {
             self.section
@@ -393,14 +393,14 @@ impl<'a> text::Actions for BuildAstActions<'a> {
         name: Option<&str>,
         wasm_ty: walrus::TypeId,
         webidl_ty: WebidlTypeRef,
-        params: IncomingBindingMap,
-        result: OutgoingBindingMap,
+        params: Option<IncomingBindingMap>,
+        result: Option<OutgoingBindingMap>,
     ) {
         let id: ExportBindingId = self.section.bindings.insert(ExportBinding {
             wasm_ty,
             webidl_ty,
-            params,
-            result,
+            params: params.unwrap_or_else(|| IncomingBindingMap { bindings: vec![] }),
+            result: result.unwrap_or_else(|| OutgoingBindingMap { bindings: vec![] }),
         });
         if let Some(name) = name {
             self.section


### PR DESCRIPTION
Fix #17.

This PR has 2 patches: One for the `text-parser` crate, the other for the main crate.