### PR TITLE
feat(ast) Add the `Binds.indices` field

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -253,6 +253,10 @@ pub struct Binds {
 }
 
 impl Binds {
+    pub fn by_index(&self, index: u32) -> Option<Id<Bind>> {
+        self.indices.get(index as usize).cloned()
+    }
+
     pub fn get(&self, id: Id<Bind>) -> Option<&Bind> {
         self.arena.get(id.into())
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -248,7 +248,8 @@ impl FunctionBindings {
 
 #[derive(Clone, Debug, Default)]
 pub struct Binds {
-    pub(crate) arena: id_arena::Arena<Bind>,
+    indices: Vec<Id<Bind>>,
+    pub(crate) arena: Arena<Bind>,
 }
 
 impl Binds {
@@ -261,7 +262,10 @@ impl Binds {
     }
 
     pub fn insert(&mut self, bind: Bind) -> Id<Bind> {
-        self.arena.alloc(bind)
+        let id = self.arena.alloc(bind);
+        self.indices.push(id);
+
+        id
     }
 }
 


### PR DESCRIPTION
This patch applies the same pattern used by `ast::WebidlBindings`
and `ast::FunctionBindings`: It exposes a new `Binds.indices`
field, and the `Binds.by_index` method.