### PR TITLE
Allow iteration over `Binds`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -263,6 +263,10 @@ impl Binds {
     pub fn insert(&mut self, bind: Bind) -> Id<Bind> {
         self.arena.alloc(bind)
     }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (Id<Bind>, &'a Bind)> + 'a {
+        self.arena.iter()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
That way if you're trying to find a binding by name or via a different
lookup, we can take a look at everything!