### PR TITLE
Determine whether a binding is expressible *without* Web IDL bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ walrus = "0.8.0"
 wasm-webidl-bindings-text-parser = { path = "crates/text-parser", optional = true }
 id-arena = "2.2.1"
 quickcheck = { version = "0.8.5", optional = true }
-rand = { version = "0.7.0", optional = true }
+rand = { version = "0.6.5", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.3.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -981,7 +981,12 @@ pub struct ImportBinding {
 }
 
 impl ImportBinding {
-    fn is_expressible_in_js_without_webidl_bindings(
+    /// Is this import binding expressible in JS without Web IDL bindings, and
+    /// without a polyfill for them?
+    ///
+    /// See `FunctionBinding::is_expressible_in_js_without_webidl_bindings` for
+    /// details.
+    pub fn is_expressible_in_js_without_webidl_bindings(
         &self,
         module: &walrus::Module,
         wb: &WebidlBindings,
@@ -1009,7 +1014,12 @@ pub struct ExportBinding {
 }
 
 impl ExportBinding {
-    fn is_expressible_in_js_without_webidl_bindings(
+    /// Is this export binding expressible in JS without Web IDL bindings, and
+    /// without a polyfill for them?
+    ///
+    /// See `FunctionBinding::is_expressible_in_js_without_webidl_bindings` for
+    /// details.
+    pub fn is_expressible_in_js_without_webidl_bindings(
         &self,
         module: &walrus::Module,
         wb: &WebidlBindings,
@@ -1040,7 +1050,12 @@ pub struct OutgoingBindingMap {
 }
 
 impl OutgoingBindingMap {
-    fn is_expressible_in_js_without_webidl_bindings(
+    /// Is this outgoing binding map expressible in JS without Web IDL bindings,
+    /// and without a polyfill for them?
+    ///
+    /// See `FunctionBinding::is_expressible_in_js_without_webidl_bindings` for
+    /// details.
+    pub fn is_expressible_in_js_without_webidl_bindings(
         &self,
         from_wasm_tys: &[walrus::ValType],
         to_webidl_tys: &[WebidlTypeRef],
@@ -1092,7 +1107,12 @@ pub struct IncomingBindingMap {
 }
 
 impl IncomingBindingMap {
-    fn is_expressible_in_js_without_webidl_bindings(
+    /// Is this incoming binding map expressible in JS without Web IDL bindings,
+    /// and without a polyfill for them?
+    ///
+    /// See `FunctionBinding::is_expressible_in_js_without_webidl_bindings` for
+    /// details.
+    pub fn is_expressible_in_js_without_webidl_bindings(
         &self,
         from_webidl_tys: &[WebidlTypeRef],
         to_wasm_tys: &[walrus::ValType],


### PR DESCRIPTION
In the context of a JS embedder that does *not* implement the Web IDL bindings proposal, are this binding's ingoing and outgoing conversions losslessly expressible with the default conversions of the WebAssembly JavaScript interface and the ECMAScript bindings for Web IDL?

This is primarily a question that is only relevant to polyfills for Web IDL bindings, such as `wasm-bindgen`.

For both incoming and outgoing values, the conversions are not expressible if each value is referenced more than once in the binding map, or the values are referenced out of order. Failure to meet this criteria would result in swapped, garbage, extra, or not enough parameters/results.

In addition to the arity and usage requirements, each value's type must also be trivially convertible. This property depends on whether the value is incoming or outgoing.

When passing outgoing Wasm values to Web IDL, first they are converted to JS values via the [`ToJSValue` algorithm defined by the WebAssembly JavaScript interface](https://webassembly.github.io/spec/js-api/index.html#tojsvalue). Next, these JS values then they are converted into Web IDL values via [Web IDL's ECMAScript type mapping](https://heycam.github.io/webidl/#es-type-mapping).

```text
+------------+                                 +----------+                                        +---------------+
| Wasm value | ---WebAssembly-JS-interface---> | JS value | ---ECMAScript-bindings-for-Web-IDL---> | Web IDL value |
+------------+                                 +----------+                                        +---------------+
```

For outgoing values to be expressible without Web IDL bindings, nor extra glue or conversions, they must be an `as` operator performing on of the following conversions from a Wasm value type to a Web IDL type:

| From Wasm valtype             | To Web IDL Type     |
|-------------------------------|---------------------|
| `i32`, `f32`, `f64`, `anyref` | `any`                                                                               |
| `i32`                         | `long`, `long long`, `float`, `unrestricted float`, `double`, `unrestricted double` |
| `f32`                   | `unrestricted float`, `unrestricted double`                                               |
| `f64`                   | `unrestricted double`                                                                     |

When passing Web IDL values to Wasm, first they are converted to JS values via the [Web IDL's ECMAScript type mapping](https://heycam.github.io/webidl/#es-type-mapping), and then those JS values are converted into Wasm values according to the [`ToWebAssemblyValue` algorithm defined by the WebAssembly JavaScript interface](https://webassembly.github.io/spec/js-api/index.html#towebassemblyvalue).

```text
+---------------+                                         +----------+                                 +---------------+
| Web IDL value |  ---ECMAScript-bindings-for-Web-IDL---> | JS value | ---WebAssembly-JS-interface---> | Web IDL value |
+---------------+                                         +----------+                                 +---------------+
```

For incoming values to be expressible without Web IDL bindings, nor extra glue or conversions, they must be an incoming binding expression of the form `(as (get <i>))` that is performing one of the following conversions from a Web IDL type to a Wasm type:

| From Web IDL Type | To Wasm valtype |
|-------------------|-----------------|
| `any`                                                                                                                               | `anyref`        |
| `byte`, `short`, `long`                                                                                                             | `i32`           |
| `byte`, `octet`, `short`, `unsigned short`, `float`, `unrestricted float`                                                           | `f32`           |
| `byte`, `octet`, `short`, `unsigned short`, `long`, `unsigned long`, `float`, `unrestricted float`, `double`, `unrestricted double` | `f64`           |

---------------

+cc @lukewagner