### PR TITLE
Migrate from failure to anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT/Apache-2.0"
 readme = "./README.md"
 
 [dependencies]
-failure = { version = "0.1.5", features = ['std'], default-features = false }
+anyhow = "1.0.18"
 leb128 = "0.2.4"
-walrus = "0.12.0"
+walrus = "0.13.0"
 wasm-webidl-bindings-text-parser = { version = "=0.5.0", path = "crates/text-parser", optional = true }
 id-arena = "2.2.1"
 quickcheck = { version = "0.8.5", optional = true }

--- a/crates/text-parser/Cargo.toml
+++ b/crates/text-parser/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 lalrpop = "0.17.1"
 
 [dependencies]
-failure = "0.1.5"
+anyhow = "1.0.18"
 lalrpop-util = "0.17.1"
 leb128 = "0.2.4"
 regex = "1.1.7"

--- a/crates/text-parser/src/parser.rs
+++ b/crates/text-parser/src/parser.rs
@@ -13,7 +13,7 @@ include!(concat!(env!("OUT_DIR"), "/grammar.rs"));
 pub fn parse_with_actions<A>(
     actions: &mut A,
     input: &str,
-) -> Result<A::WebidlBindingsSection, failure::Error>
+) -> anyhow::Result<A::WebidlBindingsSection>
 where
     A: Actions,
 {
@@ -22,7 +22,7 @@ where
 
     let ast = WebidlBindingsSectionParser::new()
         .parse(input, actions, lexer)
-        .map_err(|e| failure::format_err!("{}", e))?;
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     Ok(ast)
 }
 

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -23,7 +23,7 @@ where
 ///
 /// This does *not* parse the custom section discriminant and "webidl-bindings"
 /// custom section name, just the inner data.
-pub fn decode(ids: &walrus::IndicesToIds, from: &[u8]) -> Result<WebidlBindings, failure::Error> {
+pub fn decode(ids: &walrus::IndicesToIds, from: &[u8]) -> anyhow::Result<WebidlBindings> {
     let mut cx = DecodeContext::new(ids);
     let mut from = from;
     WebidlBindings::decode(&mut cx, &mut from)?;
@@ -32,10 +32,7 @@ pub fn decode(ids: &walrus::IndicesToIds, from: &[u8]) -> Result<WebidlBindings,
 
 /// Callback for `walrus::ModuleConfig::on_parse` to parse the webidl bindings
 /// custom section if one is found.
-pub fn on_parse(
-    module: &mut walrus::Module,
-    ids: &walrus::IndicesToIds,
-) -> Result<(), failure::Error> {
+pub fn on_parse(module: &mut walrus::Module, ids: &walrus::IndicesToIds) -> anyhow::Result<()> {
     let section = match module.customs.remove_raw("webidl-bindings") {
         Some(s) => s,
         None => return Ok(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 
 ```rust
 #[cfg(feature = "text")]
-# fn foo() -> Result<(), failure::Error> {
+# fn foo() -> anyhow::Result<()> {
 use wasm_webidl_bindings::{binary, text};
 
 // Get the `walrus::Module` that this webidl-bindings section is for.

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,7 +7,7 @@ pub fn parse(
     module: &walrus::Module,
     indices_to_ids: &walrus::IndicesToIds,
     input: &str,
-) -> Result<crate::ast::WebidlBindings, failure::Error> {
+) -> anyhow::Result<crate::ast::WebidlBindings> {
     let mut bindings = crate::ast::WebidlBindings::default();
     let mut actions = crate::ast::BuildAstActions::new(&mut bindings, module, indices_to_ids);
     parse_with_actions(&mut actions, input)?;


### PR DESCRIPTION
The failure crate invents its own traits that don't use
std::error::Error (because failure predates certain features added to
Error); this prevents using ? on an error from failure in a function
using Error. The anyhow crate integrates with the standard Error trait
instead.

walrus 0.13.0 migrated from failure to anyhow; update to that version
and migrate accordingly.